### PR TITLE
fix: correct grammar for compliation

### DIFF
--- a/syntaxes/ash.yml
+++ b/syntaxes/ash.yml
@@ -49,7 +49,6 @@ patterns:
     endCaptures:
       '1':
         name: punctuation.terminator.java
-    name: keyword.control.java  # Shouldn't need this line, but we do.
     patterns:
       - include: '#string-import'
       - include: '#strings'

--- a/syntaxes/ash.yml
+++ b/syntaxes/ash.yml
@@ -43,10 +43,12 @@ fileTypes:
 patterns:
   - begin: ^\s*\b(import)\b
     beginCaptures:
-      '1': keyword.control.java
+      '1':
+        name: keyword.control.java
     end: '(;)?\s*$'
     endCaptures:
-      '1': punctuation.terminator.java
+      '1':
+        name: punctuation.terminator.java
     name: keyword.control.java  # Shouldn't need this line, but we do.
     patterns:
       - include: '#string-import'


### PR DESCRIPTION
The grammar works as-is, but doesn't compile with `linguist/grammar-compiler` due to the incorrect syntax in `patterns`.

I've also removed the line that you "shouldn't need": I think the reason it didn't work was because the `beginCaptures` section was incorrect.